### PR TITLE
160251554 Enable caterers save meals with the same name

### DIFF
--- a/client/src/components/meals/MealItem.jsx
+++ b/client/src/components/meals/MealItem.jsx
@@ -21,6 +21,9 @@ const MealItem = ({
               <h4 data-for="price"
                 data-tip={meal.price}
                 className="black-text light-text wrap-text">Price: &#8358;{meal.price}</h4>
+              {meal.user && meal.user.username &&
+                <h4 className="black-text light-text wrap-text">Caterer: {meal.user.username}</h4>
+              }
               {showOrder &&
               <NavLink to={`/customer/orders/confirm/${meal.id}`} className="btn btn-secondary">Order</NavLink>
               }

--- a/server/controllers/MealController.js
+++ b/server/controllers/MealController.js
@@ -22,7 +22,6 @@ class MealController {
         image = result;
       }
     }
-
     // add meal to db
     const meal = await meals.add({
       name: request.body.name.trim(),

--- a/server/controllers/MenuController.js
+++ b/server/controllers/MenuController.js
@@ -158,6 +158,14 @@ class MenuController {
         order: [
           ['id', 'DESC'],
         ],
+        include: [{
+          model: Models.Users,
+          as: 'user',
+          attributes: {
+            exclude: ['accountType', 'password', 'resetPasswordToken', 'resetPasswordExpires',
+              'createdAt', 'updatedAt'],
+          },
+        }],
       }],
       attributes: { exclude: ['createdAt', 'updatedAt'] },
       limit,

--- a/server/db/meals.js
+++ b/server/db/meals.js
@@ -1,6 +1,6 @@
 import { isEmpty } from 'lodash';
 import { Op, Sequelize } from 'sequelize';
-import { Meals as MealModel } from '../models';
+import { Meals as MealModel, Users as UserModel } from '../models';
 import paginator from '../utils/paginator';
 
 
@@ -101,6 +101,14 @@ class Meals {
    */
   static get(id, paranoid = true) {
     return MealModel.findById(id, {
+      include: [{
+        model: UserModel,
+        as: 'user',
+        attributes: {
+          exclude: ['accountType', 'password', 'resetPasswordToken', 'resetPasswordExpires',
+            'createdAt', 'updatedAt'],
+        },
+      }],
       attributes: { exclude: ['createdAt', 'updatedAt', 'deletedAt'] },
       order: [['createdAt', 'DESC']],
       paranoid,
@@ -127,6 +135,14 @@ class Meals {
           Sequelize.fn('lower', Sequelize.col('name')),
           Sequelize.fn('lower', name),
         ),
+      include: [{
+        model: UserModel,
+        as: 'user',
+        attributes: {
+          exclude: ['accountType', 'password', 'resetPasswordToken', 'resetPasswordExpires',
+            'createdAt', 'updatedAt'],
+        },
+      }],
       attributes: { exclude: ['createdAt', 'updatedAt', 'deletedAt'] },
       order: [['createdAt', 'DESC']],
       paranoid,
@@ -155,6 +171,14 @@ class Meals {
    */
   static getAll(paranoid = true, limit = 10, offset = 0, mealName = '') {
     return MealModel.findAndCountAll({
+      include: [{
+        model: UserModel,
+        as: 'user',
+        attributes: {
+          exclude: ['accountType', 'password', 'resetPasswordToken', 'resetPasswordExpires',
+            'createdAt', 'updatedAt'],
+        },
+      }],
       attributes: { exclude: ['createdAt', 'updatedAt', 'deletedAt'] },
       order: [['createdAt', 'DESC']],
       paranoid,
@@ -204,6 +228,14 @@ class Meals {
             Sequelize.col('name'),
           ), 'LIKE', `%${mealName.toLowerCase()}%`),
       },
+      include: [{
+        model: UserModel,
+        as: 'user',
+        attributes: {
+          exclude: ['accountType', 'password', 'resetPasswordToken', 'resetPasswordExpires',
+            'createdAt', 'updatedAt'],
+        },
+      }],
       attributes: { exclude: ['createdAt', 'updatedAt', 'deletedAt'] },
       order: [['createdAt', 'DESC']],
       paranoid,

--- a/server/db/menus.js
+++ b/server/db/menus.js
@@ -2,7 +2,7 @@ import { isEmpty } from 'lodash';
 import { Op, Sequelize } from 'sequelize';
 import { getNormalDate } from '../utils/dateBeautifier';
 import MealUtils from '../utils/meals/mealUtils';
-import { Menus as MenuModel, Meals as MealModel } from '../models';
+import { Menus as MenuModel, Meals as MealModel, Users as UserModel } from '../models';
 import paginator from '../utils/paginator';
 
 /**
@@ -125,6 +125,14 @@ class Menus {
         model: MealModel,
         as: 'meals',
         attributes: { exclude: ['createdAt', 'updatedAt', 'MenuMeals'] },
+        include: [{
+          model: UserModel,
+          as: 'user',
+          attributes: {
+            exclude: ['accountType', 'password', 'resetPasswordToken', 'resetPasswordExpires',
+              'createdAt', 'updatedAt'],
+          },
+        }],
       }],
       attributes: { exclude: ['createdAt', 'updatedAt'] },
       order: [['createdAt', 'DESC']],
@@ -167,6 +175,14 @@ class Menus {
         order: [
           ['id', 'DESC'],
         ],
+        include: [{
+          model: UserModel,
+          as: 'user',
+          attributes: {
+            exclude: ['accountType', 'password', 'resetPasswordToken', 'resetPasswordExpires',
+              'createdAt', 'updatedAt'],
+          },
+        }],
       }],
       attributes: { exclude: ['createdAt', 'updatedAt'] },
       offset,
@@ -201,6 +217,14 @@ class Menus {
           userId,
         },
         attributes: { exclude: ['createdAt', 'updatedAt', 'MenuMeals'] },
+        include: [{
+          model: UserModel,
+          as: 'user',
+          attributes: {
+            exclude: ['accountType', 'password', 'resetPasswordToken', 'resetPasswordExpires',
+              'createdAt', 'updatedAt'],
+          },
+        }],
       }],
       attributes: { exclude: ['createdAt', 'updatedAt'] },
       limit,

--- a/server/middlewares/meals/validateMeal.js
+++ b/server/middlewares/meals/validateMeal.js
@@ -53,6 +53,8 @@ class ValidateMeal {
 
   /**
    * static method to validate that a meal name exists
+   * if current caterer has a meal with the same name, return error
+   * if another caterer has a meal with the same name, then create for current caterer
    * throws an error if name exists
    * @param {object} request
    * @param {object} response
@@ -64,11 +66,13 @@ class ValidateMeal {
       const result = await meals.getByName(request.body.name.trim());
       if (!isEmpty(result.meals)
         && result.meals[0].id !== parseInt(request.params.id, 10)) {
-        request.errors.name = {
-          message: 'Meal name already exists',
-          statusCode: 409,
-        };
-        return next();
+        if (result.meals[0].userId === request.decoded.user.id) {
+          request.errors.name = {
+            message: 'Meal name already exists',
+            statusCode: 409,
+          };
+          return next();
+        }
       }
       return next();
     }

--- a/server/models/meals.js
+++ b/server/models/meals.js
@@ -3,10 +3,6 @@ export default (sequelize, DataTypes) => {
     name: {
       type: DataTypes.STRING,
       allowNull: false,
-      unique: {
-        args: true,
-        msg: 'Meal name already exists',
-      },
       validate: {
         notEmpty: {
           args: true,
@@ -38,6 +34,7 @@ export default (sequelize, DataTypes) => {
   Meals.associate = (models) => {
     // associations can be defined here
     Meals.belongsTo(models.Users, {
+      as: 'user',
       foreignKey: 'userId',
       onDelete: 'CASCADE',
     });

--- a/server/tests/db/meals.test.js
+++ b/server/tests/db/meals.test.js
@@ -36,11 +36,6 @@ describe('Test suite for meals model', () => {
     expect(result.err.message).to.equal('Meal name is required');
   });
 
-  it('should require a unique meal name', async () => {
-    const result = await meals.add(curryRice);
-    expect(result.err.message).to.equal('Meal name already exists');
-  });
-
   it('should require price', async () => {
     const result = await meals.add({
       name: riceAndStew.name,


### PR DESCRIPTION
#### What does this PR do?
Adds feature to enable caterers save meals with the same name

#### Description of Task to be completed?
- allow caterer create a meal with the same name as another caterer
- display caterer name on meal cards when displaying to customers

#### How should this be manually tested?
- `npm run test:client`
- `npm run test:server`
- login / signup as a caterer
- create a meal
- login / signup as another caterer
- try to create a meal with the same name as the previous meal
- it should allow you create the meal with the same name
- navigate to the manage meals page, you should see the meal cards with the names of the caterers on it
- setup the menu for the day and add a few meals
- login / signup as a customer
- navigate to the view menu page, you should see the meal cards with the names of the caterers on it

#### What are the relevant pivotal tracker stories?
#160251554

#### Any background context you want to add?

#### Screenshots
<img width="1440" alt="screen shot 2018-09-07 at 12 03 32 am" src="https://user-images.githubusercontent.com/13545380/45189571-95226100-b231-11e8-8da6-237e1de03a45.png">
